### PR TITLE
Improved PATH export

### DIFF
--- a/A_Setup/setup-gcc.sh
+++ b/A_Setup/setup-gcc.sh
@@ -44,4 +44,4 @@ echo MAKE INSTALL-TARGET-LIBGCC:
 sudo make install-target-libgcc
 echo HERE U GO MAYBE:
 ls /usr/local/i386elfgcc/bin
-export PATH=$PATH:/usr/local/i386elfgcc/bin
+export PATH="$PATH:/usr/local/i386elfgcc/bin"


### PR DESCRIPTION
I got an error about "bad variable name" when running the script and realized it was just because I have a somewhat complicated PATH already with spaces in it, and the lack of quotes on line 47 made the script freak out and not add the folder i386elfgcc/bin folder to my path

Added quotes.