### PR TITLE
read and write floppies

### DIFF
--- a/CPU/Interrupts/irq.cpp
+++ b/CPU/Interrupts/irq.cpp
@@ -23,87 +23,91 @@ extern "C" void irq15();
 
 
 void *irq_routines[16] =
-{
-	0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0
-};
+        {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
 
 
 void irq_install_handler(int irq, void (*handler)(struct regs *r))
 {
-	irq_routines[irq] = (void*)handler;
+    irq_routines[irq] = (void*)handler;
 }
 
 
 void irq_uninstall_handler(int irq)
 {
-	irq_routines[irq] = 0;
+    irq_routines[irq] = 0;
 }
 
 
 void irq_remap(void)
 {
-	outb(0x20, 0x11);
-	outb(0xA0, 0x11);
-	outb(0x21, 0x20);
-	outb(0xA1, 0x28);
-	outb(0x21, 0x04);
-	outb(0xA1, 0x02);
-	outb(0x21, 0x01);
-	outb(0xA1, 0x01);
-	outb(0x21, 0x0);
-	outb(0xA1, 0x0);
+    outb(0x20, 0x11);
+    outb(0xA0, 0x11);
+    outb(0x21, 0x20);
+    outb(0xA1, 0x28);
+    outb(0x21, 0x04);
+    outb(0xA1, 0x02);
+    outb(0x21, 0x01);
+    outb(0xA1, 0x01);
+    outb(0x21, 0x0);
+    outb(0xA1, 0x0);
 }
 
+static volatile int currentInterrupts[15];
 
 void irq_install()
 {
-	irq_remap();
+    irq_remap();
 
-	idt_set_gate(32, (unsigned)irq0, 0x08, 0x8E);
-	idt_set_gate(33, (unsigned)irq1, 0x08, 0x8E);
-	idt_set_gate(34, (unsigned)irq2, 0x08, 0x8E);
-	idt_set_gate(35, (unsigned)irq3, 0x08, 0x8E);
-	idt_set_gate(36, (unsigned)irq4, 0x08, 0x8E);
-	idt_set_gate(37, (unsigned)irq5, 0x08, 0x8E);
-	idt_set_gate(38, (unsigned)irq6, 0x08, 0x8E);
-	idt_set_gate(39, (unsigned)irq7, 0x08, 0x8E);
-	idt_set_gate(40, (unsigned)irq8, 0x08, 0x8E);
-	idt_set_gate(41, (unsigned)irq9, 0x08, 0x8E);
-	idt_set_gate(42, (unsigned)irq10, 0x08, 0x8E);
-	idt_set_gate(43, (unsigned)irq11, 0x08, 0x8E);
-	idt_set_gate(44, (unsigned)irq12, 0x08, 0x8E);
-	idt_set_gate(45, (unsigned)irq13, 0x08, 0x8E);
-	idt_set_gate(46, (unsigned)irq14, 0x08, 0x8E);
-	idt_set_gate(47, (unsigned)irq15, 0x08, 0x8E);
+    idt_set_gate(32, (unsigned)irq0, 0x08, 0x8E);
+    idt_set_gate(33, (unsigned)irq1, 0x08, 0x8E);
+    idt_set_gate(34, (unsigned)irq2, 0x08, 0x8E);
+    idt_set_gate(35, (unsigned)irq3, 0x08, 0x8E);
+    idt_set_gate(36, (unsigned)irq4, 0x08, 0x8E);
+    idt_set_gate(37, (unsigned)irq5, 0x08, 0x8E);
+    idt_set_gate(38, (unsigned)irq6, 0x08, 0x8E);
+    idt_set_gate(39, (unsigned)irq7, 0x08, 0x8E);
+    idt_set_gate(40, (unsigned)irq8, 0x08, 0x8E);
+    idt_set_gate(41, (unsigned)irq9, 0x08, 0x8E);
+    idt_set_gate(42, (unsigned)irq10, 0x08, 0x8E);
+    idt_set_gate(43, (unsigned)irq11, 0x08, 0x8E);
+    idt_set_gate(44, (unsigned)irq12, 0x08, 0x8E);
+    idt_set_gate(45, (unsigned)irq13, 0x08, 0x8E);
+    idt_set_gate(46, (unsigned)irq14, 0x08, 0x8E);
+    idt_set_gate(47, (unsigned)irq15, 0x08, 0x8E);
+
+    for(int i = 0; i < 16; i++){
+        currentInterrupts[i] = 0;
+    }
 }
 
-int currentInterrupt = -1;
 
 extern "C" void _irq_handler(struct regs *r)
 {
-	currentInterrupt = r -> int_no;
-	void (*handler)(struct regs *r);
-
-	
-	handler = (void (*)(regs*))irq_routines[r->int_no - 32];
-	if (handler)
-	{
-		handler(r);
-	}
+    currentInterrupts[r -> int_no - 32] = 1;
+    void (*handler)(struct regs *r);
 
 
-	if (r->int_no >= 40)
-	{
-		outb(0xA0, 0x20);
-	}
+    handler = (void (*)(regs*))irq_routines[r->int_no - 32];
+    if (handler)
+    {
+        handler(r);
+    }
 
 
-	outb(0x20, 0x20);
+    if (r->int_no >= 40)
+    {
+        outb(0xA0, 0x20);
+    }
+
+
+    outb(0x20, 0x20);
 }
 
 void irq_wait(int n){
-    while(currentInterrupt != n){};
-    currentInterrupt = -1;
+    while(!currentInterrupts[n]){};
+    currentInterrupts[n] = 0;
 
 }

--- a/Drivers/Floppy.h
+++ b/Drivers/Floppy.h
@@ -1,6 +1,9 @@
+#pragma once
+#include "../Utils/Typedefs.h"
+#include "port_io.h"
+
+
 void floppy_detect_drives();
-void floppy_write_cmd(int base, char cmd);
-unsigned char floppy_read_data(int base);
-void floppy_check_interrupt(int base, int *st0, int *cyl);
-int floppy_calibrate(int base);
-int floppy_reset(int base);
+int floppy_init();
+int floppy_read(int drive, uint32_t lba, void* address, uint16_t count);
+int floppy_write(int drive, uint32_t lba, void* address, uint16_t count);

--- a/Drivers/ISA_DMA.cpp
+++ b/Drivers/ISA_DMA.cpp
@@ -1,6 +1,7 @@
 #include "ISA_DMA.h"
 #include "port_io.h"
 #include "../Drivers/VGA_Text.h"
+#include "../Utils/Conversions.h"
 
 
 /*
@@ -61,7 +62,7 @@ void maskChannel(uint8_t channel, int masked){
     uint16_t port = 0x0A;
 
     if(masked){
-        out += 8;
+        out += 4;
     }
 
     if(channel >= 4){
@@ -77,10 +78,8 @@ void maskChannel(uint8_t channel, int masked){
 
 
 // the address should only be 24bits long, and have a total of 0x23ff in size
-void initFloppyDMA(uint32_t address){
+void initFloppyDMA(uint32_t address, uint16_t count){
 
-    // size of a floppy track (1.44Mib floppy) - 1, admitting 512 bytes sector
-    uint16_t count = 0x23ff;
 
 
     // idk man bitwise operations help idk how to do it without spliting in two before
@@ -137,12 +136,26 @@ void prepare_for_floppyDMA_write(){
     // outb(ISA_DMA_REGISTER_SingleChannelMask, 0x06);
     maskChannel(2, 1);
 
-    outb(ISA_DMA_REGISTER_Mode, 0x4A); // 01010110
-                                                 //single transfer, address increment, auto init, read, channel2
+    outb(ISA_DMA_REGISTER_Mode, 0x5A); // 01011010
+    //single transfer, address increment, auto init, write, channel2
 
     // unmask DMA channel 2
     // outb(ISA_DMA_REGISTER_SingleChannelMask, 0x02);
+    maskChannel(2, 0);
+
+}
+
+void prepare_for_floppyDMA_read(){
+    // mask channel 2, and 0 (admiting 0 is already masked)
+    // outb(ISA_DMA_REGISTER_SingleChannelMask, 0x06);
     maskChannel(2, 1);
+
+    outb(ISA_DMA_REGISTER_Mode, 0x56); // 01010110
+    //single transfer, address increment, autoinit, read, channel2
+
+    // unmask DMA channel 2
+    // outb(ISA_DMA_REGISTER_SingleChannelMask, 0x02);
+    maskChannel(2, 0);
 
 }
 

--- a/Drivers/ISA_DMA.h
+++ b/Drivers/ISA_DMA.h
@@ -4,7 +4,8 @@
 #include "../Utils/Typedefs.h"
 
 void maskChannel(uint8_t channel, int masked);
-void initFloppyDMA(uint32_t address);
+void initFloppyDMA(uint32_t address, uint16_t count);
+void prepare_for_floppyDMA_read();
 void prepare_for_floppyDMA_write();
 
 


### PR DESCRIPTION
re-did floppy driver
fixed ISA_DMA
fixed irq_wait not working when the emulator runs faster than the os

added a debug option to the Makefile
to use this option you should connect gdb to localhost:1234 after launching "make debug".

Keep in mind default gdb will crash when you change from 16bit to 32bit.
you should use this patched version instead: https://github.com/franchioping/Patched-gdb