### PR TITLE
Add curl to setup

### DIFF
--- a/A_Setup/setup-gcc-debian.sh
+++ b/A_Setup/setup-gcc-debian.sh
@@ -1,6 +1,6 @@
 # nasm and qemu
-sudo apt install nasm
-sudo apt install qemu
+sudo apt-get install nasm
+sudo apt-get install qemu
 sudo apt-get install qemu-kvm
 
 # GCC cross compiler for i386 systems (might take quite some time, prepare food)
@@ -13,6 +13,9 @@ sudo apt install libgmp3-dev
 sudo apt install libmpc-dev
 sudo apt install libmpfr-dev
 sudo apt install texinfo
+
+#cURL (needed to clone some required files)
+sudo apt-get install curl
 
 export PREFIX="/usr/local/i386elfgcc"
 export TARGET=i386-elf

--- a/contributions.md
+++ b/contributions.md
@@ -10,6 +10,9 @@
 ### 29 JUNE 2022 - MAstcharub:
 1. Fixed Write Sector Function in the Disk Driver.
 1. Added `identify_ata` function in the Disk Driver.
+---
+### 5 NOVEMBER 2022 - YehudaElyasaf:
+1. Added cURL installation to Debian's setup script.
 
 TODO: Add Shell Comand for `identify_ata`.
 


### PR DESCRIPTION
In some Debian-based distros, curl is not installed by default.