### PR TITLE
Added pop-os check to install grub dependencies to setup-gcc-debian.sh

### DIFF
--- a/A_Setup/linux_distros/setup-gcc-debian.sh
+++ b/A_Setup/linux_distros/setup-gcc-debian.sh
@@ -3,8 +3,13 @@ sudo apt-get install nasm
 sudo apt-get install qemu
 sudo apt-get install qemu-kvm
 
-# GCC cross compiler for i386 systems (might take quite some time, prepare food)
+# POP_os additional grub dependency
+[ -f /etc/os-release ] && . /etc/os-release
+if [[ "$ID" = "pop" ]]; then
+    sudo apt install grub-pc-bin
+fi
 
+# GCC cross compiler for i386 systems (might take quite some time, prepare food)
 sudo apt update
 sudo apt install build-essential
 sudo apt install bison


### PR DESCRIPTION
Added a check to setup-gcc-debian.sh to check if the user is running pop os, if so it install grub-pc-bin that otherwise prevents grub-mkrescue from creating the final .iso image